### PR TITLE
fix: only update session on load if currently in session

### DIFF
--- a/lua/session/init.lua
+++ b/lua/session/init.lua
@@ -78,7 +78,9 @@ function M.load(session)
     return
   end
 
-  M.update()
+  if vim.v.this_session ~= nil and vim.v.this_session ~= "" then
+    M.update()
+  end
 
   vim.cmd "silent! %bwipeout"
   vim.cmd.source(config.dir .. "/" .. session)


### PR DESCRIPTION
Problem:
this message gets triggered when loading a session and there is currently no session.

Solution:
only update session on load if currently in session